### PR TITLE
Handle base64 encoded EPG responses

### DIFF
--- a/pkg/server/xtreamHandles.go
+++ b/pkg/server/xtreamHandles.go
@@ -283,6 +283,21 @@ func (c *Config) xtreamPlayerAPI(ctx *gin.Context, q url.Values) {
 
 // ProcessResponse processes various types of xtream-codes responses
 func ProcessResponse(resp interface{}) interface{} {
+	switch r := resp.(type) {
+	case nil:
+		return r
+	case []xtream.EPGInfo:
+		return processEPGInfos(r)
+	case []*xtream.EPGInfo:
+		return processEPGInfoPointers(r)
+	case xtream.EPGInfo:
+		return processEPGInfo(r)
+	case *xtream.EPGInfo:
+		if r == nil {
+			return nil
+		}
+		return processEPGInfo(*r)
+	}
 
 	respType := reflect.TypeOf(resp)
 
@@ -296,6 +311,68 @@ func ProcessResponse(resp interface{}) interface{} {
 	default:
 	}
 	return resp
+}
+
+type epgInfoResponse struct {
+	ChannelID      string                    `json:"channel_id"`
+	Description    string                    `json:"description"`
+	End            string                    `json:"end"`
+	EPGID          xtream.FlexInt            `json:"epg_id"`
+	HasArchive     xtream.ConvertibleBoolean `json:"has_archive"`
+	ID             xtream.FlexInt            `json:"id"`
+	Lang           string                    `json:"lang"`
+	NowPlaying     xtream.ConvertibleBoolean `json:"now_playing"`
+	Start          string                    `json:"start"`
+	StartTimestamp xtream.Timestamp          `json:"start_timestamp"`
+	StopTimestamp  xtream.Timestamp          `json:"stop_timestamp"`
+	Title          string                    `json:"title"`
+}
+
+func processEPGInfos(epgs []xtream.EPGInfo) []epgInfoResponse {
+	result := make([]epgInfoResponse, 0, len(epgs))
+	for _, epg := range epgs {
+		result = append(result, newEPGInfoResponse(epg))
+	}
+	return result
+}
+
+func processEPGInfoPointers(epgs []*xtream.EPGInfo) []epgInfoResponse {
+	result := make([]epgInfoResponse, 0, len(epgs))
+	for _, epg := range epgs {
+		if epg == nil {
+			continue
+		}
+		result = append(result, newEPGInfoResponse(*epg))
+	}
+	return result
+}
+
+func processEPGInfo(epg xtream.EPGInfo) epgInfoResponse {
+	return newEPGInfoResponse(epg)
+}
+
+func newEPGInfoResponse(epg xtream.EPGInfo) epgInfoResponse {
+	return epgInfoResponse{
+		ChannelID:      epg.ChannelID,
+		Description:    decodeBase64Value(epg.Description),
+		End:            epg.End,
+		EPGID:          epg.EPGID,
+		HasArchive:     epg.HasArchive,
+		ID:             epg.ID,
+		Lang:           epg.Lang,
+		NowPlaying:     epg.NowPlaying,
+		Start:          epg.Start,
+		StartTimestamp: epg.StartTimestamp,
+		StopTimestamp:  epg.StopTimestamp,
+		Title:          decodeBase64Value(epg.Title),
+	}
+}
+
+func decodeBase64Value(value xtream.Base64Value) string {
+	if len(value) == 0 {
+		return ""
+	}
+	return string(value)
 }
 
 func processXtreamArray(arr interface{}) interface{} {

--- a/vendor/github.com/tellytv/go.xtream-codes/base64.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/base64.go
@@ -6,6 +6,7 @@ package xtreamcodes
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"reflect"
 )
@@ -42,17 +43,33 @@ func (bv *Base64Value) String() string {
 
 // UnmarshalJSON sets bv to the bytes represented in the base64url encoding b.
 func (bv *Base64Value) UnmarshalJSON(b []byte) error {
-	if len(b) < 2 || b[0] != byte('"') || b[len(b)-1] != byte('"') {
+	var encoded string
+	if err := json.Unmarshal(b, &encoded); err != nil {
 		return errors.New("value is not a string")
 	}
 
-	out := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)-2))
-	n, err := base64.RawURLEncoding.Decode(out, b[1:len(b)-1])
-	if err != nil {
-		return err
+	encodings := []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.URLEncoding,
+		base64.StdEncoding.WithPadding(base64.NoPadding),
+		base64.StdEncoding,
+	}
+
+	var (
+		out []byte
+		err error
+	)
+
+	for _, encoding := range encodings {
+		out, err = encoding.DecodeString(encoded)
+		if err == nil {
+			v := reflect.ValueOf(bv).Elem()
+			v.SetBytes(out)
+			return nil
+		}
 	}
 
 	v := reflect.ValueOf(bv).Elem()
-	v.SetBytes(out[:n])
+	v.SetBytes([]byte(encoded))
 	return nil
 }


### PR DESCRIPTION
## Summary
- decode and normalize Xtream EPG responses so title and description fields return readable text
- extend Base64Value unmarshalling to support multiple base64 encodings and gracefully fall back to raw strings

## Testing
- go test ./pkg/server
- go test ./pkg/xtream-proxy
- go test ./... *(fails: pkg/utils/error_utils_test.go ExampleErrorFormats should be niladic)*


------
https://chatgpt.com/codex/tasks/task_e_68cda2e48358832ebb9eb174ea7f11f7