### PR TITLE
Preserve Base64Value string encoding

### DIFF
--- a/vendor/github.com/tellytv/go.xtream-codes/base64.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/base64.go
@@ -8,36 +8,48 @@ import (
 	"encoding/base64"
 	"errors"
 	"reflect"
+	"strings"
+	"sync"
 )
 
 // Base64Value is a base64url encoded json object,
 type Base64Value []byte
+
+var (
+	base64EncodingCache = struct {
+		sync.RWMutex
+		data map[*Base64Value]*base64.Encoding
+	}{data: make(map[*Base64Value]*base64.Encoding)}
+)
 
 // New returns a pointer to a Base64Value, cast from the given byte slice.
 // This is a convenience function, handling the address creation that a direct
 // cast would not allow.
 func New(b []byte) *Base64Value {
 	v := Base64Value(b)
+	setBase64Encoding(&v, base64.RawURLEncoding)
 	return &v
 }
 
 // NewFromString returns a Base64Value containing the decoded data in encoded.
 func NewFromString(encoded string) (*Base64Value, error) {
-	out, err := base64.RawURLEncoding.DecodeString(encoded)
+	out, enc, err := decodeBase64String(encoded)
 	if err != nil {
 		return nil, err
 	}
 
-	return New(out), nil
+	v := Base64Value(out)
+	setBase64Encoding(&v, enc)
+	return &v, nil
 }
 
 // MarshalJSON returns the ba64url encoding of bv for JSON representation.
 func (bv *Base64Value) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + base64.RawURLEncoding.EncodeToString(*bv) + "\""), nil
+	return []byte("\"" + encodeBase64String(bv) + "\""), nil
 }
 
 func (bv *Base64Value) String() string {
-	return base64.RawURLEncoding.EncodeToString(*bv)
+	return encodeBase64String(bv)
 }
 
 // UnmarshalJSON sets bv to the bytes represented in the base64url encoding b.
@@ -46,13 +58,109 @@ func (bv *Base64Value) UnmarshalJSON(b []byte) error {
 		return errors.New("value is not a string")
 	}
 
-	out := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)-2))
-	n, err := base64.RawURLEncoding.Decode(out, b[1:len(b)-1])
+	decoded, enc, err := decodeBase64String(string(b[1 : len(b)-1]))
 	if err != nil {
 		return err
 	}
 
 	v := reflect.ValueOf(bv).Elem()
-	v.SetBytes(out[:n])
+	v.SetBytes(decoded)
+	setBase64Encoding(bv, enc)
 	return nil
+}
+
+func encodeBase64String(bv *Base64Value) string {
+	if bv == nil {
+		return ""
+	}
+
+	enc := getBase64Encoding(bv)
+	return enc.EncodeToString(*bv)
+}
+
+func decodeBase64String(encoded string) ([]byte, *base64.Encoding, error) {
+	candidates := candidateEncodings(encoded)
+	var lastErr error
+
+	for _, enc := range candidates {
+		if out, err := enc.DecodeString(encoded); err == nil {
+			return out, enc, nil
+		} else {
+			lastErr = err
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("invalid base64 value")
+	}
+
+	return nil, nil, lastErr
+}
+
+func candidateEncodings(encoded string) []*base64.Encoding {
+	guess := guessEncoding(encoded)
+	encs := []*base64.Encoding{guess}
+
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	} {
+		if enc != guess {
+			encs = append(encs, enc)
+		}
+	}
+
+	return encs
+}
+
+func guessEncoding(encoded string) *base64.Encoding {
+	padded := strings.ContainsRune(encoded, '=')
+
+	for i := 0; i < len(encoded); i++ {
+		switch encoded[i] {
+		case '+', '/':
+			if padded {
+				return base64.StdEncoding
+			}
+			return base64.RawStdEncoding
+		case '-', '_':
+			if padded {
+				return base64.URLEncoding
+			}
+			return base64.RawURLEncoding
+		}
+	}
+
+	if padded {
+		return base64.StdEncoding
+	}
+
+	return base64.RawURLEncoding
+}
+
+func setBase64Encoding(bv *Base64Value, enc *base64.Encoding) {
+	if bv == nil {
+		return
+	}
+
+	base64EncodingCache.Lock()
+	base64EncodingCache.data[bv] = enc
+	base64EncodingCache.Unlock()
+}
+
+func getBase64Encoding(bv *Base64Value) *base64.Encoding {
+	if bv == nil {
+		return base64.RawURLEncoding
+	}
+
+	base64EncodingCache.RLock()
+	enc, ok := base64EncodingCache.data[bv]
+	base64EncodingCache.RUnlock()
+	if ok && enc != nil {
+		return enc
+	}
+
+	return base64.RawURLEncoding
 }

--- a/vendor/github.com/tellytv/go.xtream-codes/base64_test.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/base64_test.go
@@ -1,0 +1,36 @@
+package xtreamcodes
+
+import "testing"
+
+func TestBase64ValueStringMatchesMarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+	}{
+		{name: "PaddedStandard", encoded: "dGVzdA=="},
+		{name: "URLSafe", encoded: "-_8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var value Base64Value
+			if err := value.UnmarshalJSON([]byte("\"" + tt.encoded + "\"")); err != nil {
+				t.Fatalf("UnmarshalJSON failed: %v", err)
+			}
+
+			if got := value.String(); got != tt.encoded {
+				t.Fatalf("String() = %q, want %q", got, tt.encoded)
+			}
+
+			marshaled, err := value.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON failed: %v", err)
+			}
+
+			expected := "\"" + tt.encoded + "\""
+			if string(marshaled) != expected {
+				t.Fatalf("MarshalJSON = %q, want %q", string(marshaled), expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- track the base64 encoding used when decoding Base64Value data so marshal and string outputs preserve alphabet and padding
- add unit coverage to confirm Base64Value.String matches the marshaled form for standard and URL-safe inputs

## Testing
- go test ./vendor/github.com/tellytv/go.xtream-codes -run TestBase64ValueStringMatchesMarshal -count=1
- go test ./... *(fails: pkg/utils example test definitions and xtream-codes fixtures are missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb257bb3c832e96da7c85f2f37bc9